### PR TITLE
feat: Add environment variable for execution interval configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ all resources in the cluster. You can specify a comma-separated list of resource
 export API_RESOURCES_TO_WATCH=pods,deployments
 ```
 
+You can use environment variable `EXECUTION_INTERVAL_MINUTES` to configure how often the controller reconciles resources.
+The value must be a positive integer representing the interval in minutes. Defaults to `5`.
+
+```console
+export EXECUTION_INTERVAL_MINUTES=10
+```
+
 ## Deploying on Kubernetes
 ### Using Helm
 For the chart associated to this project, see [TwiN/helm-charts](https://github.com/TwiN/helm-charts):

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,7 +30,8 @@ const (
 
 	ListLimit = 500 // Maximum number of items to list at once
 
-	APIResourcesToWatchEnv = "API_RESOURCES_TO_WATCH"
+	APIResourcesToWatchEnv     = "API_RESOURCES_TO_WATCH"
+	ExecutionIntervalMinutesEnv = "EXECUTION_INTERVAL_MINUTES"
 )
 
 var (
@@ -37,6 +39,7 @@ var (
 
 	listTimeoutSeconds     = int64(60)
 	executionFailedCounter = 0
+	executionInterval      = ExecutionInterval
 
 	logger       *slog.Logger  // Global logger
 	programLevel slog.LevelVar // Info by default
@@ -62,6 +65,15 @@ func init() {
 		apiResourcesToWatch = strings.Split(os.Getenv(APIResourcesToWatchEnv), ",")
 	}
 
+	// Parse the execution interval from the environment
+	if v := os.Getenv(ExecutionIntervalMinutesEnv); v != "" {
+		minutes, err := strconv.Atoi(v)
+		if err != nil || minutes <= 0 {
+			panic(fmt.Sprintf("invalid value for %s: must be a positive integer, got %q", ExecutionIntervalMinutesEnv, v))
+		}
+		executionInterval = time.Duration(minutes) * time.Minute
+	}
+
 }
 
 func main() {
@@ -82,8 +94,8 @@ func main() {
 			logger.Info(fmt.Sprintf("Execution was successful after %d failed attempts, resetting counter to 0", executionFailedCounter))
 			executionFailedCounter = 0
 		}
-		logger.Info(fmt.Sprintf("Execution took %dms, sleeping for %s", time.Since(start).Milliseconds(), ExecutionInterval))
-		time.Sleep(ExecutionInterval)
+		logger.Info(fmt.Sprintf("Execution took %dms, sleeping for %s", time.Since(start).Milliseconds(), executionInterval))
+		time.Sleep(executionInterval)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -67,13 +67,21 @@ func init() {
 
 	// Parse the execution interval from the environment
 	if v := os.Getenv(ExecutionIntervalMinutesEnv); v != "" {
-		minutes, err := strconv.Atoi(v)
-		if err != nil || minutes <= 0 {
-			panic(fmt.Sprintf("invalid value for %s: must be a positive integer, got %q", ExecutionIntervalMinutesEnv, v))
+		d, err := parseExecutionIntervalMinutes(v)
+		if err != nil {
+			panic(fmt.Sprintf("invalid value for %s: %s", ExecutionIntervalMinutesEnv, err))
 		}
-		executionInterval = time.Duration(minutes) * time.Minute
+		executionInterval = d
 	}
 
+}
+
+func parseExecutionIntervalMinutes(v string) (time.Duration, error) {
+	minutes, err := strconv.Atoi(v)
+	if err != nil || minutes <= 0 {
+		return 0, fmt.Errorf("must be a positive integer, got %q", v)
+	}
+	return time.Duration(minutes) * time.Minute, nil
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -183,6 +183,39 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+func TestParseExecutionIntervalMinutes(t *testing.T) {
+	scenarios := []struct {
+		input         string
+		expected      time.Duration
+		expectError   bool
+	}{
+		{input: "5", expected: 5 * time.Minute},
+		{input: "1", expected: 1 * time.Minute},
+		{input: "60", expected: 60 * time.Minute},
+		{input: "0", expectError: true},
+		{input: "-1", expectError: true},
+		{input: "abc", expectError: true},
+		{input: "", expectError: true},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.input, func(t *testing.T) {
+			got, err := parseExecutionIntervalMinutes(scenario.input)
+			if scenario.expectError {
+				if err == nil {
+					t.Errorf("expected error for input %q, got nil", scenario.input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for input %q: %v", scenario.input, err)
+				}
+				if got != scenario.expected {
+					t.Errorf("expected %v, got %v", scenario.expected, got)
+				}
+			}
+		})
+	}
+}
+
 func newUnstructuredWithAnnotations(apiVersion, kind, namespace, name string, creationTimestamp time.Time, annotations map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
The execution interval was previously hardcoded to 5 minutes. This change allows operators to tune reconciliation frequency via environment variable without rebuilding the image — useful for clusters where resources need faster or slower TTL checks.
## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.

main.go:
  - Added strconv import
  - Added ExecutionIntervalMinutesEnv = "EXECUTION_INTERVAL_MINUTES" constant
  - Added executionInterval = ExecutionInterval variable (defaults to 5 minutes)
  - In init(): parses EXECUTION_INTERVAL_MINUTES env var — must be a positive integer, panics with a clear message if invalid
  - Updated main() loop to use executionInterval instead of the const ExecutionInterval
  - Extracted the parsing logic into parseExecutionIntervalMinutes(v string) (time.Duration, error) so it's independently testable
 
main_test.go:
  - Added TestParseExecutionIntervalMinutes covering valid inputs ("5", "1", "60"), and invalid ones ("0", "-1", "abc", "")
  - All 7 cases pass, full suite is green

  README.md:
  - Added documentation for EXECUTION_INTERVAL_MINUTES alongside the existing API_RESOURCES_TO_WATCH section